### PR TITLE
Remove redundant category in release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -33,9 +33,6 @@ categories:
   - title: 'CI bumps'
     labels:
       - 'github_actions'
-  - title: 'Other bumps'
-    labels:
-      - 'dependencies'
 version-resolver:
   major:
     labels:


### PR DESCRIPTION
## What?
Uncategorised changes will appear at the top of the release

## Checklist
- [ ] Label added to the PR (major, minor, patch, bump, etc.)
- [ ] PR up to date with default branch
- [ ] All checks are green
