### PR TITLE
Fix trading212 merchant col in different indexes

### DIFF
--- a/backend/finance_tracker/entries/trading212_entry.py
+++ b/backend/finance_tracker/entries/trading212_entry.py
@@ -14,7 +14,7 @@ class Trading212Entry:
     time: str
     total: float
     currency_total: str
-    merchant_name: str
+    merchant_name: str # To be deprecated in next major version, as it can be simplified and use action only.
 
     def quantity(self) -> Money:
         """

--- a/backend/finance_tracker/entries/trading212_entry.py
+++ b/backend/finance_tracker/entries/trading212_entry.py
@@ -14,7 +14,7 @@ class Trading212Entry:
     time: str
     total: float
     currency_total: str
-    merchant_name: str # To be deprecated in next major version, as it can be simplified and use action only.
+    merchant_name: str  # To be deprecated in next major version, as it can be simplified and use action only.
 
     def quantity(self) -> Money:
         """

--- a/backend/finance_tracker/readers/trading212_reader.py
+++ b/backend/finance_tracker/readers/trading212_reader.py
@@ -10,8 +10,7 @@ class Trading212Reader(BaseReader):
     Reader for Trading212 full-export CSV files.
     """
 
-    _HEADERS_TO_IGNORE = 1
-    _MERCHANT_COL = 19
+    _MERCHANT_COL_NAME = "Merchant name"
 
     def read_from_file(self, path_to_file: str) -> list:
         """
@@ -23,8 +22,11 @@ class Trading212Reader(BaseReader):
         entries = []
         with open(path_to_file, "r", encoding=ENCODING) as file:
             csvreader = csv.reader(file, delimiter=",")
-            for _ in range(self._HEADERS_TO_IGNORE):
-                next(csvreader)
+            headers = next(csvreader)
+            merchant_col = next(
+                (i for i, h in enumerate(headers) if h.strip() == self._MERCHANT_COL_NAME),
+                None,
+            )
 
             for row in csvreader:
                 if not row:
@@ -43,7 +45,7 @@ class Trading212Reader(BaseReader):
                         time=row[1],
                         total=float(total_str),
                         currency_total=row[14],
-                        merchant_name=row[self._MERCHANT_COL] if len(row) > self._MERCHANT_COL else "",
+                        merchant_name=row[merchant_col] if merchant_col is not None and len(row) > merchant_col else "",
                     )
                 )
 

--- a/backend/tests/readers/files/test_trading212_reader_merchant_at_col_17.csv
+++ b/backend/tests/readers/files/test_trading212_reader_merchant_at_col_17.csv
@@ -1,0 +1,2 @@
+Action,Time,ISIN,Ticker,Name,Notes,ID,No. of shares,Price / share,Currency (Price / share),Exchange rate,Result,Currency (Result),Total,Currency (Total),Withholding tax,Currency (Withholding tax),Merchant name,Merchant category,French transaction tax,Currency (French transaction tax)
+Card debit,2024-03-15 10:30:00,,,,,,,,,,,,-25.50,EUR,,,Coffee Shop,,,

--- a/backend/tests/readers/files/test_trading212_reader_merchant_at_col_19.csv
+++ b/backend/tests/readers/files/test_trading212_reader_merchant_at_col_19.csv
@@ -1,0 +1,2 @@
+Action,Time,ISIN,Ticker,Name,Notes,ID,No. of shares,Price / share,Currency (Price / share),Exchange rate,Result,Currency (Result),Total,Currency (Total),Withholding tax,Currency (Withholding tax),Currency conversion fee,Currency (Currency conversion fee),Merchant name,Merchant category,French transaction tax,Currency (French transaction tax)
+Card debit,2024-03-15 10:30:00,,,,,,,,,,,,-25.50,EUR,,,,,Coffee Shop,,,

--- a/backend/tests/readers/files/test_trading212_reader_one_card_debit_entry.csv
+++ b/backend/tests/readers/files/test_trading212_reader_one_card_debit_entry.csv
@@ -1,2 +1,2 @@
-Action,Time,ISIN,Ticker,Name,Shares,Price,Currency(Price),ExchangeRate,Result,Currency(Result),Sub-total,Currency(Sub-total),Total,Currency(Total),FromAccount,ToAccount,ID,Notes,Merchant
+Action,Time,ISIN,Ticker,Name,Shares,Price,Currency(Price),ExchangeRate,Result,Currency(Result),Sub-total,Currency(Sub-total),Total,Currency(Total),FromAccount,ToAccount,ID,Notes,Merchant name
 Card debit,2024-03-15 10:30:00,,,,,,,,,,,,-25.50,EUR,,,,,Coffee Shop

--- a/backend/tests/readers/files/test_trading212_reader_several_entries.csv
+++ b/backend/tests/readers/files/test_trading212_reader_several_entries.csv
@@ -1,4 +1,4 @@
-Action,Time,ISIN,Ticker,Name,Shares,Price,Currency(Price),ExchangeRate,Result,Currency(Result),Sub-total,Currency(Sub-total),Total,Currency(Total),FromAccount,ToAccount,ID,Notes,Merchant
+Action,Time,ISIN,Ticker,Name,Shares,Price,Currency(Price),ExchangeRate,Result,Currency(Result),Sub-total,Currency(Sub-total),Total,Currency(Total),FromAccount,ToAccount,ID,Notes,Merchant name
 Card debit,2024-03-15 10:30:00,,,,,,,,,,,,-25.50,EUR,,,,,Coffee Shop
 Card debit,2024-03-16 11:00:00,,,,,,,,,,,,-10.00,EUR,,,,,Supermarket
 Market buy,2024-03-17 09:00:00,,,,,,,,,,,,100.00,EUR,,,,

--- a/backend/tests/readers/test_trading212_reader.py
+++ b/backend/tests/readers/test_trading212_reader.py
@@ -68,3 +68,27 @@ def test_trading212_reader_does_nothing_on_empty_file(reader):
     result = reader.read_from_file(path_to_file=path_to_file)
 
     assert len(result) == 0
+
+
+def test_trading212_reader_finds_merchant_when_at_col_17(reader):
+    current_path = pathlib.Path(__file__).parent.resolve()
+    path_to_file = f"{current_path}/files/test_trading212_reader_merchant_at_col_17.csv"
+    result = reader.read_from_file(path_to_file=path_to_file)
+
+    assert len(result) == 1
+    assert result[0].action == "Card debit"
+    assert result[0].total == -25.50
+    assert result[0].currency_total == "EUR"
+    assert result[0].merchant_name == "Coffee Shop"
+
+
+def test_trading212_reader_finds_merchant_when_at_col_19(reader):
+    current_path = pathlib.Path(__file__).parent.resolve()
+    path_to_file = f"{current_path}/files/test_trading212_reader_merchant_at_col_19.csv"
+    result = reader.read_from_file(path_to_file=path_to_file)
+
+    assert len(result) == 1
+    assert result[0].action == "Card debit"
+    assert result[0].total == -25.50
+    assert result[0].currency_total == "EUR"
+    assert result[0].merchant_name == "Coffee Shop"


### PR DESCRIPTION
## What?
Merchant col can be in different indexes, we will look for it first before discarding headers.

## Checklist
- [x] Label added to the PR (`major`, `minor`, `patch`, etc.)
- [x] Type of change label added to the PR (`documentation`, `bug`, `feature`, etc.)
